### PR TITLE
validate_snils if > 2 digits fix

### DIFF
--- a/vitya/validators.py
+++ b/vitya/validators.py
@@ -147,6 +147,8 @@ def validate_snils(snils: str) -> None:
         checksum_str = "00"
     else:
         checksum = checksum % 101
+        if checksum > 99: 
+            checksum = checksum % 100
         if checksum < 10:
             checksum_str = f"0{checksum}"
         else:


### PR DESCRIPTION
```
- сумма делится на 101
- последние две цифры остатка от деления являются Контрольным числом.
```

Не проверялась длинна остатка от деления на 101
Например если `checksum = sum(results) = 201` то `201 % 101 = 100` и это сравнивалось с правильным контрольным числом  00 => wrong checksum